### PR TITLE
Added exact date for cloud sunset in migration faq

### DIFF
--- a/src/pages/migration/other/FAQs.md
+++ b/src/pages/migration/other/FAQs.md
@@ -18,7 +18,7 @@ If you encounter difficulties migrating your cloud Micros to Space Apps, you can
 
 ### Will my Micros, Bases, Drives Continue to work?
 
-Yes, they will continue to work until May 1, 2023. After that they will be sunset.
+Yes, they will continue to work until May 1, 2023 4:00 PM UTC+1. After that they will be sunset.
 
 You will continue to be able to update Micros as well as use your Bases and Drives until May 1, but you won't be able to create new Projects or Micros.
 


### PR DESCRIPTION
I think it would be useful to have the exact time until deta cloud sunsets in the faq