### PR TITLE
Added `Can I host a Discord Bot?` guide to `manual faq`

### DIFF
--- a/src/pages/manual/faq.md
+++ b/src/pages/manual/faq.md
@@ -14,3 +14,16 @@ If you want to build your own apps on Space, checkout our [developer documentati
 
 
 If your question is not listed here, checkout our [help page](/manual/help) on how to get in touch with us.
+
+
+## Can I Host a Discord Bot?
+
+Yes, you can, but there are some limitation. Discord bots on Discord can only use interactions, such as slash commands, buttons, context menus, modals, etc.
+
+#### Technical Limitations
+
+Libraries like disocrd.py use websockets to continuously connect discord. However, due to Deta being a serverless platform, requests/connections can remain active for only up to 20 seconds this includes the previously mentioned interactions (If this limit is exceeded, a timeout error will be returned). The time limit can be extended by storing the necessary information (an example of this system can be found in the discohook library).
+
+#### Recommended Libraries
+- [Discohook](https://github.com/jnsougata/discohook)
+- [Discord Interactions Js](https://github.com/discord/discord-interactions-js)


### PR DESCRIPTION
This guide goes over some of the information and technical details about hosting discord bots on deta space 