### PR TITLE
Fixed `space release` url in releases

### DIFF
--- a/src/pages/docs/en/basics/releases.md
+++ b/src/pages/docs/en/basics/releases.md
@@ -38,7 +38,7 @@ Pass the `--notes` argument to add notes about the release (changes, features, e
 
 Then watch your app take off! Your app is now installable on Deta Space to anyone with the release url.
 
-> You can provide specific options to your release (which revision to use, version tags, listed/unlisted) using specific options. See the cli reference for [`space release`](/docs/en/reference/cli#deta-release).
+> You can provide specific options to your release (which revision to use, version tags, listed/unlisted) using specific options. See the cli reference for [`space release`](/docs/en/reference/cli#space-release).
 
 ## Discovery & App Pages
 

--- a/src/pages/docs/en/reference/drive/about.md
+++ b/src/pages/docs/en/reference/drive/about.md
@@ -13,6 +13,6 @@ Deta Drive is great for projects where you need to store files or when you want 
 ## Getting started
 
 - [Dealing with data in a Space App](/docs/en/basics/data)
-- [Drive UI](/docs/en/reference/drive/base_ui)
+- [Drive UI](/docs/en/reference/drive/drive_ui)
 - [Drive SDK](/docs/en/reference/drive/sdk)
 - [Drive HTTP API](/docs/en/reference/drive/HTTP)


### PR DESCRIPTION
Small fix for the url to go to the correct section

*Note: Ignore first two commits*