### PR TITLE
feat/toc-depth

### DIFF
--- a/src/components/docs/Article/Article.svelte
+++ b/src/components/docs/Article/Article.svelte
@@ -30,7 +30,7 @@
     <h1 style="margin-top: var(--spacing-10);"><a href="#content">{frontmatter.title}</a></h1>
     <slot />
   </article>
-    <DesktopTableOfContents pageTitle={frontmatter.title} {headings} />
+    <DesktopTableOfContents pageTitle={frontmatter.title} {headings} maxDepth={frontmatter.tocDepth || 2}/>
 </div>
 
 <style lang="scss">

--- a/src/components/docs/Article/ArticleHeader.svelte
+++ b/src/components/docs/Article/ArticleHeader.svelte
@@ -32,7 +32,7 @@
     <Breadcrumbs currentPage={currentPage} stuck={stuck} />
 
     <div class="toc">
-      <MobileTableOfContents chevron pageTitle={frontmatter.title} {headings} collapsable={true} />
+      <MobileTableOfContents chevron pageTitle={frontmatter.title} {headings} collapsable={true} maxDepth={frontmatter.tocDepth || 2}/>
     </div>
 
   </div>

--- a/src/components/docs/Header/Header.svelte
+++ b/src/components/docs/Header/Header.svelte
@@ -54,7 +54,7 @@
             </li>
 
             <li class="only-mobile">
-                <MobileTableOfContents pageTitle={frontmatter ? frontmatter.title : 'Title'} {headings} collapsable={true} />
+                <MobileTableOfContents pageTitle={frontmatter ? frontmatter.title : 'Title'} {headings} collapsable={true} maxDepth={frontmatter.tocDepth || 2}/>
             </li>
         </ul>
     </div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,6 +3,7 @@ import { z, defineCollection } from "astro:content";
 // 2. Define your collection(s)
 export const docsSchema = z.object({
   title: z.string().optional(),
+  tocDepth: z.number().optional(),
   excerpt: z.string().optional()
 });
 export const docsCollection = defineCollection({

--- a/src/content/docs/build/reference/spacefile.md
+++ b/src/content/docs/build/reference/spacefile.md
@@ -1,5 +1,6 @@
 ---
 title: The Spacefile
+tocDepth: 5
 layout: "@layouts/DocsPageLayout.astro"
 ---
 


### PR DESCRIPTION
Allows overriding of max Depth for table of contents. by setting `tocDepth: X` frontmatter property.
Useful for pages like: https://deta.space/docs/en/build/reference/spacefile where we want to show all items at once.