### PR TITLE
fix: migration layout styling

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -2,6 +2,8 @@
 import type { MarkdownHeading } from 'astro';
 import * as CONFIG from '../config';
 
+import '../styles/old-index.css';
+
 import TeletypeContainer from '../components/Teletype/TeletypeContainer.astro';
 import HeadCommon from '../components/HeadCommon.astro';
 import HeadSEO from '../components/HeadSEO.astro';
@@ -127,6 +129,24 @@ const baseTitle = isManual ? 'Space Manual' : isMigration ? 'Migration Hub' : 'S
 				display: block;
 				top: 2rem;
 			}
+
+            /* QUICK FIXES UNTIL WE DO SOMETHING WITH IT */
+            article {
+                padding-inline: 2rem !important;
+                padding-right: 30rem !important;
+                padding-top: 2rem !important;
+            }
+            @media (min-width: 72em) {
+                .layout {
+                    padding-right:1.5rem !important;
+                }
+                .grid-main > * {
+                    width: inherit !important;
+                }
+                .grid-right {
+                    padding-left: 4rem !important;
+                }
+            }
 		</style>
 	</head>
 
@@ -136,7 +156,7 @@ const baseTitle = isManual ? 'Space Manual' : isMigration ? 'Migration Hub' : 'S
 			<aside id="grid-left" class="grid-sidebar" title="Site Navigation">
 				<LeftSidebar currentPage={currentPage} />
 			</aside>
-			<div id="grid-main">
+			<div id="grid-main" style="width: auto; padding-right:2rem;">
 				<PageContent frontmatter={frontmatter} headings={headings} githubEditUrl={githubEditUrl}>
 					<slot />
 				</PageContent>

--- a/src/styles/old-index.css
+++ b/src/styles/old-index.css
@@ -59,6 +59,12 @@ h6 {
 	line-height: 1;
 }
 
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+    color: var(--theme-text) !important;
+    text-decoration: none;
+    font-weight: 500;
+}
+
 h1,
 h2 {
 	max-width: 40ch;


### PR DESCRIPTION
Adds the old stylesheet back into the main layout used for the migration page and adds some quick fixes for some layout issues.