### PR TITLE
Fix/expressive code blocks styling

### DIFF
--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -17,8 +17,8 @@
 }
 
 .tab:focus {
-	outline: 2px solid var(--theme-accent);
-	outline-offset: -2px;
+    outline: none;
+    border-bottom-color: var(--theme-accent);
 }
 
 .tab:not(:focus-visible) {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -108,7 +108,7 @@ export default function Tabs({ sharedStore, defaultPanel, tabs, ...slots }: Prop
 							ref={(el) => (tabButtonRefs.current[tab.value] = el)}
 							onClick={() => updateCurr(tab.value, tabButtonRefs.current[tab.value])}
 							aria-selected={curr === tab.value}
-							tabIndex={curr === tab.value ? 0 : -1}
+							tabIndex={curr === tab.value ? -1 : 0}
 							role="tab"
 							type="button"
 							className={styles.tab}

--- a/src/content/docs/build/fundamentals/development/local-development.mdx
+++ b/src/content/docs/build/fundamentals/development/local-development.mdx
@@ -13,7 +13,7 @@ After you setup your [Builder Project](/docs/en/build/fundamentals/development/p
 
 To start your app locally, run the `space dev` command in your local project:
 
-```
+```shell
 space dev
 ```
 
@@ -31,7 +31,7 @@ Before you can spin up your app locally with `space dev`, make sure you have you
 
 The Space CLI will use development command(s) you provide in your `Spacefile` to start each of your app's Micros locally, specified by `dev` parameter:
 
-```yaml
+```yaml title="Spacefile"
 v: 0
 micros:
   - name: client
@@ -148,7 +148,7 @@ You can also trigger [Scheduled Actions](/docs/en/build/fundamentals/the-space-r
 
 Let's assume we have the following `Spacefile` that runs a `cleanup` action on a schedule:
 
-```yaml
+```yaml title="Spacefile"
 v: 0
 micros:
   - name: backend
@@ -228,7 +228,7 @@ If you do not want to use `space dev` for whatever reason, but still need to tal
 
 You can set this Data Key into your local development environment as `DETA_PROJECT_KEY`, and the SDK will automatically pick the correct key up, both in development and in production, for you and any end users of your app.
 
-```
+```shell
 // .env.example
 
 DETA_PROJECT_KEY="MY_DATA_KEY"

--- a/src/content/docs/build/fundamentals/development/projects.md
+++ b/src/content/docs/build/fundamentals/development/projects.md
@@ -14,7 +14,7 @@ When building apps for Space, the first thing you start with is a **Project**. A
 
 You can create new a new Project using the [Space CLI](/docs/en/build/fundamentals/space-cli). To create a new Builder Project with the Space CLI, open a new terminal, navigate into a new directory (or the directory of app you want to push to Space) and run the `space new`  command:
 
-```
+```shell
 space new
 ```
 
@@ -89,7 +89,7 @@ Your local development environment is connected to Builder via the hidden `.spa
 
 You can also connect any local directory to any existing Builder Project via this **Project ID** and the `space link` CLI command. To do so, navigate to the directory you want to link and enter the command:
 
-```
+```shell
 space link
 ```
 

--- a/src/content/docs/build/fundamentals/development/pushing.md
+++ b/src/content/docs/build/fundamentals/development/pushing.md
@@ -7,7 +7,7 @@ If you have not yet setup or run your app locally checkout the [New App Guide](/
 
 Once you are satisfied with your app in your development environment, you can run it in on the internet by “pushing” it to Deta Space. Use the Space CLI command `space push` to do so:
 
-```
+```shell
 space push
 ```
 

--- a/src/content/docs/build/fundamentals/space-cli.mdx
+++ b/src/content/docs/build/fundamentals/space-cli.mdx
@@ -20,7 +20,7 @@ The Space CLI is a command line interface you can use to build apps for Deta Spa
     <Fragment slot="win">
     To install the Space CLI on Windows, open PowerShell and enter:
 
-    ```
+    ```shell
     iwr https://deta.space/assets/space-cli.ps1 -useb | iex
     ```
     </Fragment>
@@ -38,16 +38,15 @@ This will download the binary which contains the CLI code. It will try to export
 ## Authentication
 
 Once you have successfully installed the Space CLI, you'll need to log in to Deta Space.
-
 From a terminal type:
 
-```
+```shell
 space login
 ```
 
 This command will ask for an ‘access token’ to authenticate your CLI.
 
-```
+```shell
 ? Enter access token >
 ```
 
@@ -65,7 +64,7 @@ Copy the resulting token:
 
 You can paste this back into your CLI prompt. After you hit enter, you should be greeted by a success message.
 
-```
+```shell
 👍 Login Successful!
 ```
 

--- a/src/content/docs/build/fundamentals/the-space-runtime/actions.mdx
+++ b/src/content/docs/build/fundamentals/the-space-runtime/actions.mdx
@@ -5,9 +5,9 @@ layout: "@layouts/DocsPageLayout.astro"
 
 import LangTabsSimple from "@/components/Tabs/LangTabsSimple.astro";
 
-Another useful building block you can use in your Space apps are **Actions**. An Action allows an app to run certain tasks in response to different **Triggers**. Actions can do really anything you dream up in code, like sending automated emails or collecting and cleaning up data. 
+Another useful building block you can use in your Space apps are **Actions**. An Action allows an app to run certain tasks in response to different **Triggers**. Actions can do really anything you dream up in code, like sending automated emails or collecting and cleaning up data.
 
-Currently, Space supports **Scheduled Actions**, where a time-configurable schedule will trigger an Action. 
+Currently, Space supports **Scheduled Actions**, where a time-configurable schedule will trigger an Action.
 
 ## Scheduled Actions
 
@@ -19,7 +19,7 @@ You can read more about [Scheduled Actions as a Space user here](/docs/en/use/sp
 
 You can add a Scheduled Action to your app via the [`Spacefile`](/docs/en/build/fundamentals/the-space-runtime#the-spacefile). You do so at an individual [Micro](/docs/en/build/fundamentals/the-space-runtime/micros) level, designating which Micro is responsible for carrying out what action at which interval.
 
-```yaml
+```yaml title="Spacefile"
 micros:
   - name: backend
     src: backend
@@ -48,7 +48,7 @@ When the time arrives to trigger your Action, Deta Space will send a `POST` requ
 
 For example, the `Spacefile` from the prior section would result in sending the following request body to the `backend` Micro:
 
-```
+```json
 {
   "event": {
     "id": "cleanup",

--- a/src/content/docs/build/fundamentals/the-space-runtime/index.md
+++ b/src/content/docs/build/fundamentals/the-space-runtime/index.md
@@ -11,11 +11,11 @@ Deta Space has its own runtime, the Space Runtime, that can run almost any type 
 - full-stack frameworks like [Next](https://nextjs.org/), [Nuxt](https://nuxtjs.org/), or [SvelteKit](https://kit.svelte.dev/)
 - backend apps built with Node.js, Python and even Go, Rust or something more custom
 
-An individual Space app can be built by combining these different technologies, for example, a SvelteKit app with a Go API or a Next.js app with a Python API — really any combination of up to 5 different languages and frameworks. 
+An individual Space app can be built by combining these different technologies, for example, a SvelteKit app with a Go API or a Next.js app with a Python API — really any combination of up to 5 different languages and frameworks.
 
 Learn more about building your first app in the [New Space App Guide](/docs/en/build/new-apps).
 
-### Micros 
+### Micros
 
 We call these individual parts of an app [Micros](/docs/en/build/fundamentals/the-space-runtime/micros). A Micro is a lightweight serverless compute service running inside your app that can be exposed to the world using HTTP.
 
@@ -29,13 +29,13 @@ A core part of the Space Runtime is a unique and fully managed approach to [Auth
 
 ## The `Spacefile`
 
-The Space Runtime uses a configuration file, called a `Spacefile`, to understand what Micros your app contains and how to run each one individually and in concert. The `Spacefile` must be named exactly `Spacefile` (capitalized and without an extension) and needs to be in the root directory of your project and uses a syntax similar to YAML. 
+The Space Runtime uses a configuration file, called a `Spacefile`, to understand what Micros your app contains and how to run each one individually and in concert. The `Spacefile` must be named exactly `Spacefile` (capitalized and without an extension) and needs to be in the root directory of your project and uses a syntax similar to YAML.
 
-> If you're new to YAML and want to learn more, see [Learn YAML in Y minutes](https://learnxinyminutes.com/docs/yaml/). 
+> If you're new to YAML and want to learn more, see [Learn YAML in Y minutes](https://learnxinyminutes.com/docs/yaml/).
 
 Here is an example `Spacefile` for an app with a Python Micro and a Go Micro:
 
-```yaml
+```yaml title="Spacefile"
 v: 0
 icon: ./icon.png
 app_name: "My App"
@@ -56,7 +56,7 @@ micros:
       - main
 ```
 
-The Space CLI will automatically generate a `Spacefile` for you when you [create a new project](/docs/en/build/fundamentals/development/projects#creating-a-project) using `space new`. If will try to auto detect your Micros and use the right configuration. 
+The Space CLI will automatically generate a `Spacefile` for you when you [create a new project](/docs/en/build/fundamentals/development/projects#creating-a-project) using `space new`. If will try to auto detect your Micros and use the right configuration.
 
 
 Take a look at our [Quick Starters](/docs/en/build/quick-starts/) for instructions about specific languages and the [`Spacefile` Reference](/docs/en/build/reference/spacefile) for a comprehensive list of available configuration options.
@@ -70,6 +70,7 @@ To exclude certain files and directories from being uploaded during `space push
 For example, using `space push` with the following `.spaceignore` file will ignore the `test` and `docs` paths:
 
 ```
+// .spaceignore
 test
 docs
 ```
@@ -86,24 +87,24 @@ List of files and directories that are ignored by default:
   # space
   .space
   .spaceignore
-  
+
   # version control
   .hg
   .git
   .gitmodules
   .gitignore
   .svn
-  
+
   # build
   build
   dist
-  
+
   # js frameworks
   .next
   .nuxt
   .svelte-kit
   .astro
-  
+
   # node
   node_modules
   .npmignore
@@ -114,45 +115,45 @@ List of files and directories that are ignored by default:
   yarn-error.log*
   lerna-debug.log*
   .pnpm-debug.log*
-  
+
   # python
   .venv
   venv
   virtualenv
   __pycache__
-  
+
   # rust
   target
-  
+
   # coverage
   *.lcov
   .nyc_output
   .coverage
   .coverage.*
-  
+
   # docker
   .dockerignore
-  
+
   # env
   .env.local
   .env.*.local
   .env
   .envrc
-  
+
   # ide
   .*.swp
   .vscode
   .history
-  
+
   # system
   .DS_Store
-  
+
   # other
   .lock-wscript
   config.gypi
   CVS
   ```
-    
+
 
 These patterns are always ignored, unless overwriten by a negate pattern in the `.spaceignore` file.
 
@@ -163,5 +164,7 @@ You can use an optional prefix `!` to negate a pattern; any matching file excl
 For a `.spaceignore` file with the following content, `space push` will not ignore the `node_modules` directory:
 
 ```
+// .spaceignore
+
 !node_modules/
 ```

--- a/src/content/docs/build/fundamentals/the-space-runtime/micros.md
+++ b/src/content/docs/build/fundamentals/the-space-runtime/micros.md
@@ -13,7 +13,7 @@ As mentioned in the [Space Runtime page](/docs/en/build/fundamentals/the-space-r
 
 Micros are defined in your project's [`Spacefile`](/docs/en/build/fundamentals/the-space-runtime#the-spacefile), which tells Deta Space what kinds of Micros live in your app and how to run them.
 
-## Adding a Micro 
+## Adding a Micro
 
 ### On Project Creation
 
@@ -47,7 +47,7 @@ micros:
 		dev: nodemon index.js
 ```
 
-The `name` field identifies your Micro inside your app and the `src` should point to the location of the Micro's source code relative to your project's root. 
+The `name` field identifies your Micro inside your app and the `src` should point to the location of the Micro's source code relative to your project's root.
 
 If your project contains more than one Micro, the `primary` field can be used to identify the [entry point of your application](/docs/en/build/fundamentals/the-space-runtime/micros#micro-routing) (which Micro will be executed when the root path of your app is invoked over HTTP).
 
@@ -60,7 +60,6 @@ A Micro can be thought of as its own independent service. As a result, Micros sh
 Here's the file & folder structure of an app with a Python backend and a Vue frontend:
 
 ```
-Spacefile
 backend/
     requirements.txt
     main.py
@@ -74,7 +73,7 @@ All files needed for the Vue frontend (including `package.json`) are inside the 
 
 Here is the matching `Spacefile`:
 
-```
+```yaml title="Spacefile"
 v: 0
 micros:
   - name: frontend
@@ -95,7 +94,7 @@ Since your app can contain up to five Micros, the Space Runtime needs to know wh
 
 On Space, this is handled by having a single **Primary Micro** which receives all requests made to your app's root path `/`. The Primary Micro is defined by the `primary` field in your `Spacefile`. Each other Micro will be served on a specific path relative to your app's primary hostname, defined in the Micros' `path` fields in your `Spacefile`:
 
-```
+```yaml title="Spacefile"
 v: 0
 micros:
   - name: client

--- a/src/content/docs/build/new-apps.mdx
+++ b/src/content/docs/build/new-apps.mdx
@@ -50,7 +50,7 @@ To build apps, you need the Space CLI on your local machine. Download it with on
   <Fragment slot="win">
   To install the Space CLI on Windows, open PowerShell and enter:
 
-  ```
+  ```shell
   iwr https://deta.space/assets/space-cli.ps1 -useb | iex
   ```
   </Fragment>
@@ -101,12 +101,12 @@ Your Project should now appear when you open the Builder app, where you can test
 
 ## The Space Runtime and Spacefile
 
-Deta Space has its own runtime — [the Space Runtime](/docs/en/build/fundamentals/the-space-runtime) — that can run almost any type of web app. It supports most programming languages and frameworks. 
+Deta Space has its own runtime — [the Space Runtime](/docs/en/build/fundamentals/the-space-runtime) — that can run almost any type of web app. It supports most programming languages and frameworks.
 The [`Spacefile`](/docs/en/build/fundamentals/the-space-runtime#the-spacefile) contains the configuration of your app and is used by Deta Space to understand what your app looks like and how to run it.
 
 Here's an example `Spacefile` for a [To Do app](https://github.com/deta/todo-app) built with a static frontend and a Node.js backend:
 
-```yaml
+```yaml title="Spacefile"
 # Spacefile Docs: https://go.deta.dev/docs/spacefile/v0
 v: 0
 micros:
@@ -141,7 +141,7 @@ A Space app runs on serverless compute units called [Micros](/docs/en/build/fund
 If [`space new`](/docs/en/build/new-apps#creating-a-project-with-builder) doesn't boostrap your Micro when creating a project locally, you can add it by writing to the [`Spacefile`](/docs/en/build/fudnamentals/the-space-runtime#the-spacefile).
 Create an individual Micro with the `micros` field in the `Spacefile`.
 
-```yaml
+```yaml title="Spacefile"
 v: 0
 micros:
   - name: frontend
@@ -169,7 +169,7 @@ Check out the [Spacefile reference](/docs/en/build/reference/spacefile) for all 
 
 If you're building something like a website and need parts of your app (or the whole thing) to be public facing, check out how to use the `public` or `public_routes` fields in the `Spacefile`.
 
-```yaml
+```yaml title="Spacefile"
 v: 0
 micros:
   - name: frontend
@@ -257,9 +257,7 @@ Read more about data on Space [as a developer](/docs/en/build/fundamentals/data-
 
 To use `space dev`, you will need to provide a `dev` parameter to every Micro in your `Spacefile`. The `dev` parameter is the command `space dev` uses to start a Micro's development server. Make sure the command starts your web server on the port specified with the `PORT` environment variable, with port `XXXX` as a fallback.
 
-`Spacefile`:
-
-```yaml
+```yaml title="Spacefile"
 # Spacefile Docs: https://go.deta.dev/docs/spacefile/v0
 v: 0
 micros:

--- a/src/styles/new.css
+++ b/src/styles/new.css
@@ -144,6 +144,10 @@ strong {
 .expressive-code figure div.copy div.feedback::after {
     color: hsl(var(--color-base-green), 40%) !important;
 }
+.expressive-code figure figcaption.header span.title {
+    border: none !important;
+    background: none !important;
+}
 
 /* Supporting Content */
 

--- a/src/styles/new.css
+++ b/src/styles/new.css
@@ -125,6 +125,26 @@ strong {
 	color: inherit;
 }
 
+/* Code blocks */
+.expressive-code {
+    border-radius: var(--rounded-3);
+    overflow: hidden;
+    margin-bottom: var(--spacing-7);
+}
+.expressive-code figure div.copy {
+    margin-right: var(--spacing-1);
+    margin-top: var(--spacing-1);
+}
+.expressive-code figure div.copy button {
+    border-radius: var(--rounded-2) !important;
+}
+.expressive-code figure div.copy div.feedback {
+    background: hsl(var(--color-base-green), 40%) !important;
+}
+.expressive-code figure div.copy div.feedback::after {
+    color: hsl(var(--color-base-green), 40%) !important;
+}
+
 /* Supporting Content */
 
 table {


### PR DESCRIPTION
- Adjusted styling to better match docs design.
  - Frame style
  - Copy dialog style
- Added language specifiers to improve look & highlighting of code blocks.
- Added titles to code blocks (Useful, especially so that we can remove the file title from the leading paragraph, as that does not look good).

**Before:**
![image](https://github.com/deta/space-docs/assets/73365945/fd6e6544-444f-4cf3-8211-fa5040bb7bb2)
![image](https://github.com/deta/space-docs/assets/73365945/572b96ae-96da-4771-be78-f3aef7356a4f)

---

**After changes:**
![image](https://github.com/deta/space-docs/assets/73365945/bdd5b759-8d4e-460a-91f8-8870913b3585)
![image](https://github.com/deta/space-docs/assets/73365945/f24d0f92-2b2a-4607-8bda-5f33fd9a9be5)
![image](https://github.com/deta/space-docs/assets/73365945/34c1055a-6c54-4916-8668-b0e7402e9d19)


