### PR TITLE
Update actions docs to be compatible with Pydantic v1 and v2

### DIFF
--- a/src/content/docs/build/fundamentals/the-space-runtime/actions.mdx
+++ b/src/content/docs/build/fundamentals/the-space-runtime/actions.mdx
@@ -80,11 +80,16 @@ app.post('/__space/v0/actions', (req, res) => {
 <br/>
 ```python
 # using FastAPI and Pydantic
-@app.post('/__space/v0/actions')
+class ActionEvent(BaseModel):
+    id: str
+    trigger: str
+
+class Action(BaseModel):
+    event: ActionEvent
+
+@app.post("/__space/v0/actions")
 def actions(action: Action):
-    data = action.dict()
-    event = data['event']
-    if event['id'] == 'cleanup':
+    if action.event.id == "cleanup":
         cleanup()
 ```
   </Fragment>


### PR DESCRIPTION
Pydantic v2 removes the `.dict()` method, so this change removes the use of that method in the Actions doc.
Also added the Pydantic model definitions that were missing.