### PR TITLE
New terminal tab after installing. For #142

### DIFF
--- a/src/content/docs/build/fundamentals/space-cli.mdx
+++ b/src/content/docs/build/fundamentals/space-cli.mdx
@@ -33,7 +33,7 @@ The Space CLI is a command line interface you can use to build apps for Deta Spa
     </Fragment>
 </OSTabs>
 
-This will download the binary which contains the CLI code. It will try to export the `space` command to your path, making the `space` command globally usable on your machine. If it does not succeed, follow the directions output by the install script to export `space` to your path.
+This will download the binary which contains the CLI code. It will try to export the `space` command to your path, but you may need to open a new terminal tab for the `space` command to be on your path. On Linux/Mac OS this makes the `space` command usable by the current user. <!--NOT for Linux/Mac OS X: making the `space` command globally usable on your machine.--> If it does not succeed, follow the directions output by the install script to export `space` to your path.
 
 ## Authentication
 

--- a/src/content/docs/build/new-apps.mdx
+++ b/src/content/docs/build/new-apps.mdx
@@ -63,7 +63,7 @@ To build apps, you need the Space CLI on your local machine. Download it with on
   </Fragment>
 </OSTabs>
 
-After it downloads, you need to use the command `space login` to authenticate with the CLI. This requires an **Access Token**, which you can get by clicking the **Settings** action from Teletype on your Canvas.
+After installing, you may need to open a new terminal tab for the `space` command to be on your path. Then you need to use the command `space login` to authenticate with the CLI. This requires an **Access Token**, which you can get by clicking the **Settings** action from Teletype on your Canvas.
 
 Read more about [Installing the CLI](/docs/en/build/fundamentals/space-cli) and the complete list of [CLI commands](/docs/en/build/reference/cli).
 


### PR DESCRIPTION
Please delegate to someone with Windows:

Please check what's now commented out in `src/content/docs/build/fundamentals/space-cli.mdx`: NOT for Linux/Mac OS X: making the `space` command globally usable on your machine.

The rest of this PR is as per #142.