### PR TITLE
add info box for command not found: space on cli installation

### DIFF
--- a/src/content/docs/build/fundamentals/space-cli.mdx
+++ b/src/content/docs/build/fundamentals/space-cli.mdx
@@ -35,7 +35,7 @@ The Space CLI is a command line interface you can use to build apps for Deta Spa
 
 This will download the binary which contains the CLI code. It will try to export the `space` command to your path, making the `space` command globally usable on your machine. If it does not succeed, follow the directions output by the install script to export `space` to your path.
 
-> ❗️ If you encounter `command not found: space` after a successful installation, please try to restarting your terminal session.
+> ❗️ If you encounter `command not found: space` after a successful installation, please try to restart your terminal session.
 
 
 ## Authentication

--- a/src/content/docs/build/fundamentals/space-cli.mdx
+++ b/src/content/docs/build/fundamentals/space-cli.mdx
@@ -35,6 +35,9 @@ The Space CLI is a command line interface you can use to build apps for Deta Spa
 
 This will download the binary which contains the CLI code. It will try to export the `space` command to your path, making the `space` command globally usable on your machine. If it does not succeed, follow the directions output by the install script to export `space` to your path.
 
+> ❗️ If you encounter `command not found: space` after a successful installation, please try to restarting your terminal session.
+
+
 ## Authentication
 
 Once you have successfully installed the Space CLI, you'll need to log in to Deta Space.


### PR DESCRIPTION
Adds an info box to the CLI installation page to further clarify that users need to use a new shell after installing the CLI.

See #142 for additional info.

Preview:
<img width="741" alt="image" src="https://github.com/deta/space-docs/assets/73365945/53e270af-13e2-45fc-b5ad-23064071651f">

