### PR TITLE
add cli install info box to new-apps page

### DIFF
--- a/src/content/docs/build/new-apps.mdx
+++ b/src/content/docs/build/new-apps.mdx
@@ -66,6 +66,7 @@ To build apps, you need the Space CLI on your local machine. Download it with on
 After it downloads, you need to use the command `space login` to authenticate with the CLI. This requires an **Access Token**, which you can get by clicking the **Settings** action from Teletype on your Canvas.
 
 Read more about [Installing the CLI](/docs/en/build/fundamentals/space-cli) and the complete list of [CLI commands](/docs/en/build/reference/cli).
+> ❗️ If you encounter `command not found: space` after a successful installation, please try to restart your terminal session.
 
 ## Apps on Deta Space
 


### PR DESCRIPTION
Adds the same info box from #170 to the new apps page.

Preview:
<img width="727" alt="image" src="https://github.com/deta/space-docs/assets/73365945/8bea38ae-a0d0-4f23-9698-d8ad9668276c">
