### PR TITLE
Contribution guidelines; moved .vscode/settings.json to settings.json.example; added extensions.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# Do allow versioning of .vscode/ directory itself, if we want to version some example files or
+# extensions.json.
+.vscode/settings.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,11 @@
 {
-  "recommendations": ["astro-build.astro-vscode"],
+  "recommendations": [
+    "astro-build.astro-vscode",
+    "stkb.rewrap",
+    "bierner.markdown-preview-github-styles",
+    "davidanson.vscode-markdownlint",
+    "drmerfy.overtype",
+    "streetsidesoftware.code-spell-checker"
+  ],
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": false
-}

--- a/.vscode/settings.json.example
+++ b/.vscode/settings.json.example
@@ -1,0 +1,10 @@
+{
+    "editor.formatOnSave": false,
+    "editor.rulers": [
+        100
+    ],
+    "markdownlint.config": {
+        "MD013": false,
+        "MD025": false
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Rules of thumb
+
+- Leave the last line empty. It makes `git diff` (and any `diff`) easier to review when the last
+  line is modified/appended.
+- Wrap lines. Suggest wrapping to 100 characters, which is the [Rust fmt
+  standard](https://rust-lang.github.io/rustfmt/?version=master&search=#max_width).
+
+# VS Code
+
+If you use VS Code, suggest
+
+- Do NOT add/commit your `.vscode/settings.json`. Instead,
+  - add `.vscode/settings.json` (but NOT the whole `.vscde` directory) to `.gitignore`, and
+  - share any suggested settings in `.vscode/settings.json.example` and add that to git.
+  
+- [Rewrap](https://marketplace.visualstudio.com/items?itemName=stkb.rewrap) for rewrapping comments
+  and documentation.
+  
+  Rewrap doesn't touch the source code itself, only comments (and `.md` files). It preserves
+  Markdown formatting in comments (even though it understands only one of Markdown
+  formatting/indentation way of nested lists, see source code of this file below). You can apply
+  Rewrap to Markdown (`.md`) files, too.
+  
+  If you edit existing content a lot, do NOT have Rewrap set to automatic, but use Alt+Q to rewrap
+  the current comment section (consecutive lines of comments that include the current line). Ctrl+A
+  Alt+Q rewraps all comments (in the current file).
+  
+- [Markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+  for Markdown checks. But, suggest turning off
+  
+  - [MD013 to allow long lines, for example: Markdown
+tables](https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md)
+  - [MD025 to allow multiple H1
+headings](https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md)
+  
+  How? Either by having the following at the top of the `.md` files:
+  
+  ```html
+  <!-- markdownlint-disable MD013 -->
+  <!-- markdownlint-disable MD025 -->
+  ```
+  
+  Or by the following user settings.
+  
+- Configure in Ctrl+Shift+P > Preferences: Open User Settings (JSON):
+  
+  ```json
+    "editor.rulers": [
+        100
+    ],
+    "markdownlint.config": {
+        "MD013": false,
+        "MD025": false
+    }
+  ```
+  
+- [Code Spell
+  Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
+
+- Please, share other VS Code extensions by adding them to `.vscode/extensions.json`.


### PR DESCRIPTION
I also have a list of VS Code extensions for Rust development, and general code navigation, that is not documentation/Markdown-specific. Please ping me if you know of a better repo/file to share it.