### PR TITLE
fixe: changelog padding

### DIFF
--- a/src/layouts/ChangelogLayout.astro
+++ b/src/layouts/ChangelogLayout.astro
@@ -49,6 +49,7 @@ const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
                         1fr
                     );
                 overflow-x: hidden;
+                padding-inline: 1.25rem;
             }
 
             .grid-sidebar {
@@ -113,7 +114,7 @@ const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
             }
 
             #grid-main {
-                padding: var(--doc-padding) var(--gutter);
+                padding: var(--doc-padding) 0;
                 grid-column: 2;
                 display: flex;
                 flex-direction: column;
@@ -130,6 +131,7 @@ const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
                     overflow: initial;
                     grid-template-columns: 5rem minmax(0, var(--max-width)) 5rem;
                     gap: 1em;
+                    padding-inline: 0;
                 }
             }
 

--- a/src/layouts/ChangelogsListLayout.astro
+++ b/src/layouts/ChangelogsListLayout.astro
@@ -44,6 +44,7 @@ const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
                         1fr
                     );
                 overflow-x: hidden;
+                padding-inline: 1.25rem;
             }
 
             .grid-sidebar {
@@ -61,7 +62,7 @@ const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
             }
 
             #grid-main {
-                padding: var(--doc-padding) var(--gutter);
+                padding: var(--doc-padding) 0;
                 grid-column: 2;
                 display: flex;
                 flex-direction: column;
@@ -77,6 +78,7 @@ const currentFile = `src/pages${currentPage.replace(/\/$/, '')}.md`;
                     overflow: initial;
                     grid-template-columns: 10rem minmax(0, var(--max-width));
                     gap: 1em;
+                    padding-inline: 0;
                 }
 
                 #grid-left {

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -22,7 +22,7 @@ changelogs.sort((a, b) => {
     {changelogs.map((changelog) => (
         <div class="changelog-block">  
             <a class="open-changelog" href={changelog.url}>
-                <h3 class="title">{changelog.frontmatter.title}</h3>
+                <h3 class="title" style="line-height: 1.25;">{changelog.frontmatter.title}</h3>
                 <p class="date">{formatDate(changelog.frontmatter.date)}</p>
                 <div class="arrow">→</div>
             </a>          

--- a/src/styles/old-index.css
+++ b/src/styles/old-index.css
@@ -28,6 +28,7 @@ body {
 	font-size: clamp(0.9rem, 0.75rem + 0.375vw + var(--user-font-scale), 1rem);
 	line-height: 1.5;
 	max-width: 100vw;
+    margin: 0;
 }
 
 nav ul {


### PR DESCRIPTION
- Fixes the changelog having weird margin / padding.
- Increased the changelog title line height
- With changes, the margin/padding is not consistent (was only on the left side before, right side text would hug the edge)


| Before | After |
|-|-|
| ![image](https://github.com/deta/space-docs/assets/73365945/534d4247-463a-4ec2-b442-92bd0799aa00) | ![image](https://github.com/deta/space-docs/assets/73365945/8b20b06d-9e8e-4f20-bff5-a89a45d0c29f) |

