### PR TITLE
Feat/broken link checker

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -33,14 +33,28 @@ const brokenLinkChecker = () => {
 
                 console.log("Results for possibly broken links:");
                 for (const route of routes) {
+                    if (route.route.startsWith("/changelog") || route.route.startsWith("/manual") || route.route.startsWith("/migration")) continue;
                     const fPath = route.distURL.pathname;
                     const content = await fs.readFile(fPath, "utf-8");
 
-                    const pageLinks = Array.from(content.matchAll(/<a\s[^>]*\bhref="([^#"][^"]*)"/g), (m) => m[1])
-                        .filter(e => !["/discovery", "/blog"].includes(e))
-                        .filter(l => !l.startsWith("https") && !l.startsWith("https") && !l.startsWith("mailto") && !l.startsWith("tel") && !l.startsWith("data"))
-                        .map(l => (l.indexOf("#") > -1 ? l.slice(0, l.indexOf("#")) : l))
-                        .map(l => l.endsWith("/") ? l.slice(0, -1) : l );
+                    const pageLinks = Array.from(
+                      content.matchAll(/<a\s[^>]*\bhref="([^#"][^"]*)"/g),
+                      (m) => m[1]
+                    )
+                      .filter((e) => !["/discovery", "/blog"].includes(e))
+                      // https://deta.space/docs
+                      .filter(
+                        (l) =>
+                          l.startsWith("https://deta.space/docs") ||
+                          (!l.startsWith("https") &&
+                            !l.startsWith("https") &&
+                            !l.startsWith("mailto") &&
+                            !l.startsWith("tel") &&
+                            !l.startsWith("data"))
+                      )
+                      .map((l) => (l.startsWith("https://deta.space/docs") ? l.slice(18) : l))
+                      .map((l) => (l.indexOf("#") > -1 ? l.slice(0, l.indexOf("#")) : l))
+                      .map((l) => (l.endsWith("/") ? l.slice(0, -1) : l));
 
                     for (const pLink of pageLinks) {
                         if (!pages.includes(pLink)) {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,14 +2,16 @@ import { defineConfig } from "astro/config";
 import svelte from "@astrojs/svelte";
 import mdx from "@astrojs/mdx";
 import fs from "fs/promises";
-import astroExpressiveCode from 'astro-expressive-code'
+import path from "path";
+import astroExpressiveCode from "astro-expressive-code";
 
 // TODO(@maxu): Remove these once we have them migrated!
 import react from "@astrojs/react";
 import preact from "@astrojs/preact";
 import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
-import {generateIndexPages} from './src/generate-indexes'
+import { generateIndexPages } from "./src/generate-indexes";
+import { brokenLinkIntegration } from "./src/utils/brokenLinkIntegration.mjs";
 
 const headingIcon = (node) => {
   let e = new HTMLSpanElement();
@@ -17,59 +19,16 @@ const headingIcon = (node) => {
   return [e];
 };
 
-/**
- * Small astro integration to scan all generated pages links &
- * match them with known routes to find (possibly) broken links.
- * @returns
- */
-const brokenLinkChecker = () => {
-    return {
-        name: "broken-link-checker",
-        hooks: {
-            "astro:build:done": async ({ routes, pages }) => {
-                pages = pages.map(
-                    (e) => `/${e.pathname.endsWith("/") ? e.pathname.slice(0, -1) : e.pathname}`
-                );
-
-                console.log("Results for possibly broken links:");
-                for (const route of routes) {
-                    if (route.route.startsWith("/changelog") || route.route.startsWith("/manual") || route.route.startsWith("/migration")) continue;
-                    const fPath = route.distURL.pathname;
-                    const content = await fs.readFile(fPath, "utf-8");
-
-                    const pageLinks = Array.from(
-                      content.matchAll(/<a\s[^>]*\bhref="([^#"][^"]*)"/g),
-                      (m) => m[1]
-                    )
-                      .filter((e) => !["/discovery", "/blog"].includes(e))
-                      // https://deta.space/docs
-                      .filter(
-                        (l) =>
-                          l.startsWith("https://deta.space/docs") ||
-                          (!l.startsWith("https") &&
-                            !l.startsWith("https") &&
-                            !l.startsWith("mailto") &&
-                            !l.startsWith("tel") &&
-                            !l.startsWith("data"))
-                      )
-                      .map((l) => (l.startsWith("https://deta.space/docs") ? l.slice(18) : l))
-                      .map((l) => (l.indexOf("#") > -1 ? l.slice(0, l.indexOf("#")) : l))
-                      .map((l) => (l.endsWith("/") ? l.slice(0, -1) : l));
-
-                    for (const pLink of pageLinks) {
-                        if (!pages.includes(pLink)) {
-                            console.log(`  - ${pLink} in ${fPath}`);
-                        }
-                    }
-                }
-            }
-        }
-    }
-};
-
 // https://astro.build/config
 export default defineConfig({
-  integrations: [astroExpressiveCode(), mdx(), svelte(), preact(), react(), brokenLinkChecker()],
+  integrations: [
+    astroExpressiveCode(),
+    mdx(),
+    svelte(),
+    preact(),
+    react(),
+    brokenLinkIntegration()
+  ],
   site: "https://deta.space/",
   base: "/",
   markdown: {
@@ -79,7 +38,7 @@ export default defineConfig({
     ]
   },
   experimental: {
-   viewTransitions: true
+    viewTransitions: true
   },
   vite: {
     build: {

--- a/src/utils/brokenLinkIntegration.mjs
+++ b/src/utils/brokenLinkIntegration.mjs
@@ -1,0 +1,71 @@
+import fs from "fs/promises";
+import path from "path";
+
+/**
+ * Small astro integration to scan all generated pages links &
+ * match them with known routes to find (possibly) broken links.
+ * @returns
+ */
+export const brokenLinkIntegration = () => {
+  return {
+    name: "broken-link-checker",
+    hooks: {
+      "astro:build:done": async ({ pages }) => {
+        pages = pages.map(
+          (e) => `/${e.pathname.endsWith("/") ? e.pathname.slice(0, -1) : e.pathname}`
+        );
+        // https://deta.space/docs/en/build/fundamentals/app-lifecycle
+
+
+        console.log("Results for possibly broken links:");
+
+        const searchPath = "./dist/docs";
+
+        let srcFiles = [];
+        async function getFiles(dir = "./") {
+          const entries = await fs.readdir(dir, { withFileTypes: true });
+
+          const files = entries
+            .filter((entry) => !entry.isDirectory())
+            .map((file) => ({ ...file, dir: dir + file.name }));
+
+          const folders = entries.filter((entry) => entry.isDirectory());
+          for (const folder of folders)
+            files.push(...(await getFiles(`${path.join(dir, folder.name)}`)));
+
+          return files;
+        }
+        srcFiles = (await getFiles(searchPath)).map((e) => path.join(e.path, e.name));
+
+        for (const srcFile of srcFiles) {
+          const content = await fs.readFile(srcFile, "utf-8");
+
+          const pageLinks = Array.from(
+            content.matchAll(/<a\s[^>]*\bhref="([^#"][^"]*)"/g),
+            (m) => m[1]
+          )
+            .filter((e) => !["/discovery", "/blog"].includes(e))
+            .filter(
+              (l) =>
+                l.startsWith("https://deta.space/docs") ||
+                (!l.startsWith("https") &&
+                  !l.startsWith("http") &&
+                  !l.startsWith("mailto") &&
+                  !l.startsWith("tel") &&
+                  !l.startsWith("data") &&
+                  !l.startsWith("./"))
+            )
+            .map((l) => (l.startsWith("https://deta.space/docs") ? l.slice(18) : l))
+            .map((l) => (l.indexOf("#") > -1 ? l.slice(0, l.indexOf("#")) : l))
+            .map((l) => (l.endsWith("/") ? l.slice(0, -1) : l));
+
+          for (const pLink of pageLinks) {
+            if (!pages.includes(pLink)) {
+              console.log(`  - ${pLink} in ${srcFile}`);
+            }
+          }
+        }
+      }
+    }
+  };
+};


### PR DESCRIPTION
Adds a custom Astro integration which runs after the build is done. It checks generated HTML files for relative links and compares them with the routes which exist.

Afterward, it outputs all links which do not point to a known route:

<img width="1077" alt="image" src="https://github.com/deta/space-docs/assets/73365945/47c7e1b6-05e6-4152-a7df-c50d5b176338">
