### PR TITLE
Update Spelling Mistakes new-apps.mdx

### DIFF
--- a/src/content/docs/build/new-apps.mdx
+++ b/src/content/docs/build/new-apps.mdx
@@ -94,7 +94,7 @@ To create a new project, open a new terminal, navigate into a new directory (or 
 space new
 ```
 
-Enter a name for your Project. The Space CLI should try to detect applications in your local directory. If found, you can see the config bootrapped by the CLI for those applications in a newly created file called the `Spacefile`.   If you used the Builder UI or have an existing Builder Project, you can use the CLI command `space link` to link a local directory with your Builder Project.
+Enter a name for your Project. The Space CLI should try to detect applications in your local directory. If found, you can see the config bootstrapped by the CLI for those applications in a newly created file called the `Spacefile`.   If you used the Builder UI or have an existing Builder Project, you can use the CLI command `space link` to link a local directory with your Builder Project.
 
 Your Project should now appear when you open the Builder app, where you can test, run, manage and publish your apps with Space.
 
@@ -139,7 +139,7 @@ Check out the [Spacefile reference](/docs/en/build/reference/spacefile) for all 
 
 A Space app runs on serverless compute units called [Micros](/docs/en/build/fundamentals/the-space-runtime/micros). A Space app can contain up to five Micros, which run most programming languages and frameworks.
 
-If [`space new`](/docs/en/build/new-apps#creating-a-project-with-builder) doesn't boostrap your Micro when creating a project locally, you can add it by writing to the [`Spacefile`](/docs/en/build/fudnamentals/the-space-runtime#the-spacefile).
+If [`space new`](/docs/en/build/new-apps#creating-a-project-with-builder) doesn't bootstrap your Micro when creating a project locally, you can add it by writing to the [`Spacefile`](/docs/en/build/fudnamentals/the-space-runtime#the-spacefile).
 Create an individual Micro with the `micros` field in the `Spacefile`.
 
 ```yaml title="Spacefile"


### PR DESCRIPTION
Spelling Mistakes :
- boostrap => bootstrap .
- bootrapped => bootstrapped .