### PR TITLE
Remove an odd-one-out word

### DIFF
--- a/src/content/docs/build/fundamentals/the-space-runtime/authentication.md
+++ b/src/content/docs/build/fundamentals/the-space-runtime/authentication.md
@@ -46,7 +46,7 @@ This will make every route that the given Micro serves public, in the above exam
 
 ### Public Routes
 
-You can also control turn off auth at an individual route level for any Micro with the `public_routes` keyword in your app's `Spacefile`:
+You can also turn off auth at an individual route level for any Micro with the `public_routes` keyword in your app's `Spacefile`:
 
 ```yaml
 micros:


### PR DESCRIPTION
I guess the author could not decide between "control" and "turn off", as a result there are both. In my opinion, "turn off" fits better.