### PR TITLE
Document max query objects

### DIFF
--- a/src/content/docs/build/reference/deta-base/queries.md
+++ b/src/content/docs/build/reference/deta-base/queries.md
@@ -173,6 +173,7 @@ You need to consider the following when querying on keys:
 - The keys must be strings hence the operation values **must** also be strings. 
 - The [contains](#contains) and [not-contains](#not-contains) operators **are not supported**.
 - The [`AND`](#and) and [`OR`](#or) operations for different query values **are not supported**.
+- The max number of OR operations or query objects in a list is 25.
     
 For e.g. **the following queries are invalid**:
 


### PR DESCRIPTION
The max number of OR query objects is 25 and beyond that Deta returns "Bad query" error.
